### PR TITLE
Auflistung AK Mädchenschach

### DIFF
--- a/Jugendordnung.md
+++ b/Jugendordnung.md
@@ -165,7 +165,7 @@ bis zur nächsten Jugendversammlung das Amt anderweitig zu besetzen.
 1. Der 1. Vorsitzende und die zwei stellvertretenden Vorsitzenden vertreten, jeder für sich allein, die DSJ nach außen. Sie haben die Stellung eines gesetzlichen Vertreters im Sinne von § 26 Abs. 2 BGB. Im Innenverhältnis werden die zwei stellvertretenden Vorsitzenden nur bei Verhinderung des 1. Vorsitzenden tätig.
 
 1. Zwischen den Jugendversammlungen ist der Vorstand für alle Angelegenheiten der DSJ zuständig. Er erfüllt seine Aufgaben im Rahmen dieser Jugendordnung,
-der Beschlüsse der Jugendversammlung sowie der Satzung des DSB. Er beruft dazu die Arbeitskreise Mädchenschach, Allgemeine Jugendarbeit, Öffentlichkeitsarbeit, Schulschach und Spielbetrieb, die von den jeweils zuständigen Vorstandsmitgliedern ge- leitet werden.
+der Beschlüsse der Jugendversammlung sowie der Satzung des DSB. Er beruft dazu die Arbeitskreise Mädchenschach, Allgemeine Jugendarbeit, Öffentlichkeitsarbeit, Schulschach und Spielbetrieb, die von den jeweils zuständigen Vorstandsmitgliedern geleitet werden.
 Die Koordination und die Entscheidung über grundsätzliche
 Fragen obliegt dem Vorstand nach Maßgabe der dazu ergangenen Beschlüsse der Jugendversammlung. Das Weitere regelt die Geschäftsordnung.
 

--- a/Jugendordnung.md
+++ b/Jugendordnung.md
@@ -165,8 +165,8 @@ bis zur nächsten Jugendversammlung das Amt anderweitig zu besetzen.
 1. Der 1. Vorsitzende und die zwei stellvertretenden Vorsitzenden vertreten, jeder für sich allein, die DSJ nach außen. Sie haben die Stellung eines gesetzlichen Vertreters im Sinne von § 26 Abs. 2 BGB. Im Innenverhältnis werden die zwei stellvertretenden Vorsitzenden nur bei Verhinderung des 1. Vorsitzenden tätig.
 
 1. Zwischen den Jugendversammlungen ist der Vorstand für alle Angelegenheiten der DSJ zuständig. Er erfüllt seine Aufgaben im Rahmen dieser Jugendordnung,
-der Beschlüsse der Jugendversammlung sowie der Satzung des DSB. Er beruft dazu die Arbeitskreise Allgemeine Jugendarbeit, Öffentlichkeitsarbeit,
-Schulschach und Spielbetrieb, die von dem jeweils zuständigen Vorstandsmitglied geleitet werden. Die Koordination und die Entscheidung über grundsätzliche
+der Beschlüsse der Jugendversammlung sowie der Satzung des DSB. Er beruft dazu die Arbeitskreise Mädchenschach, Allgemeine Jugendarbeit, Öffentlichkeitsarbeit, Schulschach und Spielbetrieb, die von den jeweils zuständigen Vorstandsmitgliedern ge- leitet werden.
+Die Koordination und die Entscheidung über grundsätzliche
 Fragen obliegt dem Vorstand nach Maßgabe der dazu ergangenen Beschlüsse der Jugendversammlung. Das Weitere regelt die Geschäftsordnung.
 
 1. Jedes gewählte Mitglied des Vorstandes hat in den Sitzungen dieses Gremiums


### PR DESCRIPTION
Bislang wurde der Arbeitskreis Mädchenschach nicht als Organ in der Jugend- und Geschäftsordnung aufgeführt. Da dieser Arbeitskreis seit vielen Jahren existiert und durch das zuständige Vorstandsmitglied geleitet wird, soll er entsprechend in den Ordnungen ergänzt werden.
Der Verweis auf die zuständigen Vorstandsmitglieder ist ein Vorgriff auf den folgenden Antrag, der die Zweiteilung des Spielleiteramtes anstrebt.