### PR TITLE
Aufteilung in zwei Nationale Spielleiter

### DIFF
--- a/Jugendordnung.md
+++ b/Jugendordnung.md
@@ -123,9 +123,9 @@ Der Antrag wird in der vorliegenden Form einstimmig genehmigt.
 	- Finanzreferenten,
 	- Mädchenreferenten,
 	- Referenten für allgemeine Jugendarbeit,
-	- Referenten für Öffentlichkeitsarbeit
-	- Referenten für Schulschach
-	- Nationalen Spielleiter
+	- Referenten für Öffentlichkeitsarbeit,
+	- Referenten für Schulschach,
+	- die zwei Nationalen Spielleiter
 	- und die zwei Bundesjugendsprecher.
 
 
@@ -140,7 +140,7 @@ von jeweils zwei Jahren, und zwar in den Jahren mit ungerader Endziffer den
 	- ersten Vorsitzenden,
 	- Finanzreferenten,
 	- Mädchenreferenten,
-	- Nationalen Spielleiter
+	- einen der zwei Nationalen Spielleiter
 	- und einen der zwei Bundesjugendsprecher
 
 
@@ -149,7 +149,8 @@ von jeweils zwei Jahren, und zwar in den Jahren mit ungerader Endziffer den
 	- zwei stellvertretende Vorsitzende,
 	- Referenten für allgemeine Jugendarbeit,
 	- Referenten für Öffentlichkeitsarbeit,
-	- Referenten für Schulschach
+	- Referenten für Schulschach,
+	- einen der zwei Nationalen Spielleiter
 	- und einen der zwei Bundesjugendsprecher
 
 	Die Bundesjugendsprecher müssen bei ihrer Erstwahl Jugendliche sein. Wiederwahl ist zulässig, nach Überschreiten der Altersgrenze jedoch nur noch ein Mal.


### PR DESCRIPTION
Aktuell ist der einzige DSJ-Spielleiter das ganze Jahr über sehr aktiv in das Tagesge- schäft der Meisterschaften eingebunden. Auf der einen Seite bedeutet dies für einen Ehrenamtlichen eine hohe zeitliche und mentale Belastung, die sich bei einer Zweitei- lung verringern ließe. Andererseits ist mit einer Zweiteilung des Amtes auch die Hoff- nung verknüpft, dass die Nationalen Spielleiter sich so zukünftig auch wieder verstärkt konzeptionellen Themen und der Evaluation der bestehenden Aktivitäten und Ordnun- gen widmen können. Themen wie die Überarbeitung der DVM-Kontingentberechnung, kindgerechten Regelanwendung, oder der Ausbau neuer Meisterschaftsformate blie- ben so zuletzt etwas auf der Strecke.
Es erscheint daher sinnvoll, das Amt des DSJ-Spielleiters zukünftig zweizuteilen. Dies ist in einigen Landesverbänden und Landesschachjugenden bereits genauso üblich, dort erfolgt die Aufteilung in aller Regel nach Einzel- und Mannschaftsmeisterschaften. Aufgrund der unterschiedlichen Arbeitsbelastungen durch die Charakteristika der DSJ- Meisterschaften ist eine solche starre Teilung wenig sinnvoll: Die DEM wird zentral ausgerichtet und zum Teil von der Geschäftsstelle organisiert; die DLM verfügt über verhältnismäßig wenig Teilnehmende und erfuhr zuletzt Ausrichtungen von hervorra- genden Organisationsteams der Landesverbände; die DVM dagegen bindet schon aufgrund der Vielzahl an Ausrichter, Mannschaften und Teilnehmenden viele Kräfte. Im Arbeitsumfang und der zeitlichen Belastung über das Jahr ist also eine Zweiteilung in DEM+DLM und DVM naheliegend.
Im Antrag wird eine solche starre Aufteilung der Meisterschaften auf die beiden Natio- nalen Spielleiter vermieden, um ihre kooperierende Arbeitsweise nicht zu sehr einzu- schränken. Damit den Ländern Zuständigkeiten und Ansprechpartner klar sind, soll jedoch jedes Jahr auf der Jugendversammlung bekanntgegeben werden, welcher Na- tionale Spielleiter für welche der folgenden DSJ-Turniere verantwortlich ist.
Ferner soll der in der Geschäftsordnung verankerte dreiköpfige Spielausschuss reak- tiviert werden, der fortan über die Themen entscheidet, die nicht unmittelbar dem zu- ständigen Spielleiter zugeordnet werden können. Diesem gehören voraussichtlich stets die beiden Spielleiter sowie ein weiteres AKS-Mitglied an. Da mit der Zweiteilung des Spielleiteramtes voraussichtlich auch die Größe des AKS zunimmt, werden einige der Kompetenzen, die die Jugendspielordnung (JSpO) aktuell für den AKS vorsieht, langfristig auf den Spielausschuss übergehen, um eine zügige Beschlussfassung auch im Umlaufverfahren zu gewährleisten.