### PR TITLE
Versandfrist Protokoll Jugendversammlung - Antrag der Bayerischen Sch…

### DIFF
--- a/Jugendordnung.md
+++ b/Jugendordnung.md
@@ -217,8 +217,8 @@ Bereitwilligkeit, das Amt anzunehmen, erklärt haben.
 
 ## 10. Protokoll
 
-Über jede Sitzung des Vorstandes, des Geschäftsführenden Vorstandes, der Arbeitskreise, der Ausschüsse und über die Jugendversammlung ist Protokoll zu führen. Das Protokoll muss enthalten: Eine Liste sämtlicher Anwesender, die eingereichten Anträge und die Beschlüsse mit dem Abstimmungsergebnis. Das Protokoll ist vom Protokollführer und dem Versammlungsleiter zu unterzeichnen und
-muss von der nächsten Versammlung genehmigt werden.
+Über jede Sitzung des Vorstandes, des Geschäftsführenden Vorstandes, der Arbeitskreise, der Ausschüsse und über die Jugendversammlung ist Protokoll zu führen. Das Protokoll muss enthalten: Eine Liste sämtlicher Anwesender, die eingereichten Anträge und die Beschlüsse mit dem Abstimmungsergebnis. Das Protokoll ist vom Protokollführer und dem Versammlungsleiter zu unterzeichnen und muss von der nächsten Versammlung genehmigt werden.
+Das Protokoll der Jugendversammlung muss den Landesverbänden innerhalb von sechs Wochen, gerechnet vom Tag der Jugendversammlung an, zugesendet werden.
 
 ## 11. Fachausschüsse und Beauftragte
 

--- a/Jugendordnung.md
+++ b/Jugendordnung.md
@@ -218,7 +218,7 @@ Bereitwilligkeit, das Amt anzunehmen, erklärt haben.
 ## 10. Protokoll
 
 Über jede Sitzung des Vorstandes, des Geschäftsführenden Vorstandes, der Arbeitskreise, der Ausschüsse und über die Jugendversammlung ist Protokoll zu führen. Das Protokoll muss enthalten: Eine Liste sämtlicher Anwesender, die eingereichten Anträge und die Beschlüsse mit dem Abstimmungsergebnis. Das Protokoll ist vom Protokollführer und dem Versammlungsleiter zu unterzeichnen und muss von der nächsten Versammlung genehmigt werden.
-Das Protokoll der Jugendversammlung muss den Landesverbänden innerhalb von sechs Wochen, gerechnet vom Tag der Jugendversammlung an, zugesendet werden.
+Das Protokoll der Jugendversammlung muss den Landesverbänden innerhalb von zwei Monaten, gerechnet vom letzten Tag der Jugendversammlung an, zugesendet werden.
 
 ## 11. Fachausschüsse und Beauftragte
 


### PR DESCRIPTION
Begründung: Bisher wird das Protokoll erst kurz vor der nächsten Jugendversammlung im neuen Jahr den Landesverbänden und ihren Delegierten zugesendet. Nach diesem langen Zeitraum ist es für die Teilnehmer schwer sich noch an alle Details zu erinnern und ggf. Korrekturen einzubringen.